### PR TITLE
Fix map tab initialization and layout

### DIFF
--- a/DSD-FME-GUI-BY_Kameleon.py
+++ b/DSD-FME-GUI-BY_Kameleon.py
@@ -936,11 +936,16 @@ class DSDApp(QMainWindow):
         controls.addStretch()
         layout.addLayout(controls)
 
-        self.map_view = QWebEngineView()
-        if not os.path.exists(MAP_FILE):
-            self.create_initial_map()
-        self.map_view.setUrl(QUrl.fromLocalFile(os.path.abspath(MAP_FILE)))
-        layout.addWidget(self.map_view)
+        # container where the map widget will live; store layout for later use
+        map_container = QWidget()
+        map_layout = QVBoxLayout(map_container)
+        self.widgets["map_layout"] = map_layout
+        layout.addWidget(map_container)
+
+        # initialize the map view
+        self.map_view = None
+        self.create_initial_map()
+
         return widget
     def create_initial_map(self):
         html = f"""
@@ -994,6 +999,11 @@ class DSDApp(QMainWindow):
 
         with open(MAP_FILE, 'w', encoding='utf-8') as f:
             f.write(html)
+
+        # replace existing map view if present
+        if getattr(self, "map_view", None):
+            self.widgets['map_layout'].removeWidget(self.map_view)
+            self.map_view.deleteLater()
 
         self.map_view = QWebEngineView(self)
         self.map_view.setUrl(QUrl.fromLocalFile(os.path.abspath(MAP_FILE)))


### PR DESCRIPTION
## Summary
- ensure the Map tab creates and stores a dedicated layout for the web view
- recreate map view cleanly when switching tiles or coordinate formats

## Testing
- `python -m py_compile DSD-FME-GUI-BY_Kameleon.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1901315848322bf78d6d60977ce97