### PR TITLE
Remove stray 'main' token causing syntax error

### DIFF
--- a/DSD-FME-GUI-BY_Kameleon.py
+++ b/DSD-FME-GUI-BY_Kameleon.py
@@ -1932,7 +1932,6 @@ class DSDApp(QMainWindow):
 
                 if self.is_recording.get(idx, False):
                     self.stop_internal_recording(idx)
-      main
                 self.current_id[idx] = None
                 self.current_tg[idx] = None
                 self.last_logged_id[idx] = None


### PR DESCRIPTION
## Summary
- Remove accidental `main` token left in log parser

## Testing
- `python -m py_compile DSD-FME-GUI-BY_Kameleon.py`
- `python DSD-FME-GUI-BY_Kameleon.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c1865c788322a2041585dafb34d3